### PR TITLE
Add potato.fm source-level scanner (Robinhood Chain launchpad aggregator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ rider. 🐣 NOXA EARLY (holders+volume bar — *not* the misleading `graduationP
 
 - `scan.py` — live API scanner (no RPC needed)
 
+### `potato/` — potato.fm "Potato Pad" (Robinhood Chain), source-level
+A Robinhood-chain launchpad **aggregator** (several pad factories, `kind`
+`direct`/`curve`) that plants coins straight into a locked Uniswap V3 position,
+live from block one. Its own Next.js origin ships an open, urllib-reachable API
+(not Cloudflare-walled like long.xyz), and the pad is small enough (~60 tokens
+all-time) that one page of `/api/tokens` *is* the complete board — so this is a
+source-level scanner with 100% coverage, not a trench rider. The Growing feed's
+only per-token traction is `volume24Usd` (socials inline; no holders/mcap — the
+site derives mcap from the V3 pool over RPC), so the bar is **volume + age**;
+the `/api/ancient` feed is richer (fdv/liquidity) and drives the GRAD tier.
+🥔 POTATO EARLY (young coin crossing the volume bar) + 🚀 POTATO GRAD (surfaces
+in Ancients on a real WETH pool). No API key. Prices outcomes via the shared
+`gmgn` snap (potato coins are gmgn-indexable V3 tokens). See `potato/README.md`
+and `docs/research/potato-fm-api.md`.
+
+- `scan.py` — live API scanner (no RPC needed)
+
 ### `long/` — long.xyz (Robinhood Chain, stock-token launches)
 The busiest launchpad on GMGN's robinhood trenches board (~2.4 launches/min,
 graduates at $200–400K mcap). Its own API is Cloudflare-blocked to `urllib`, so

--- a/docs/research/potato-fm-api.md
+++ b/docs/research/potato-fm-api.md
@@ -1,0 +1,115 @@
+# potato.fm API — reverse-engineered surface
+
+**Date:** 2026-07-23
+**Platform:** potato.fm ("Potato Pad"), Robinhood Chain (chainId 4663)
+**Method:** opened the site, watched the network panel, then replayed every
+endpoint from plain `urllib` server-side to confirm it's reachable without the
+browser's cookies/headers.
+
+potato.fm ships **no** developer docs. This is the surface the web app itself
+uses. It is a **Next.js app that serves its own API off the same origin**
+(`https://potato.fm/api/...`) — there is no separate `api.potato.fm` host. No
+auth, no API key. Reachable from stdlib `urllib` (it is **not** Cloudflare-walled
+the way long.xyz's own API is).
+
+The site is an **aggregator over several Robinhood-chain pad factories**, not a
+single launchpad: every token row carries a `pad` address and a `kind`
+(`direct` = launched straight into a locked Uniswap V3 position, `curve` =
+bonding-curve). Six distinct `pad` addresses seen at first sight.
+
+It also self-describes as an **unaudited demo MVP**, and behaves like one: the
+`/api/tokens` endpoint intermittently returns 502 or times out while its scan
+cache is cold (it caches an on-chain scan and serves it; `servedAt −
+scanCompletedAt` ≈ 25–35s, so freshness is ~30s, not instant). A client must
+tolerate transient failures.
+
+## REST — base `https://potato.fm/api`
+
+| Path | Notes |
+|---|---|
+| `GET /api/tokens` | the "Growing" board. `{chainId, servedAt, scanCompletedAt, state, creations:[…], unavailable}`. `creations` is the token list. `sort`/`limit` query params are accepted but currently **ignored** (fixed server-side order); at ~60 rows the whole board fits one page anyway. |
+| `GET /api/ancient` | the "Ancients" board — tokens matured onto a real WETH pool. `{tokens:[…], unavailable}`. **Richer** per-row than Growing. |
+| `GET /api/stats` | pad-wide aggregates (see below). |
+| `GET /api/profile?addresses=0x…,0x…` | creator profiles (batch). `{profiles:{addr:{username,bio,avatarUrl,…}}}`. |
+| `POST /api/rpc` | a Robinhood-chain JSON-RPC **proxy** (`eth_chainId` → `0x1237` = 4663). The frontend uses it to read each token's V3 pool and compute market cap client-side. |
+| `GET /api/tokens/{addr}`, `/api/token/{addr}` | **404** — there is no per-token detail endpoint. |
+
+### `/api/tokens` `creations` row shape
+
+```json
+{
+  "token": "0x…", "creator": "0x…", "name": "…", "symbol": "…",
+  "pool": "0x…",                       // the Uniswap V3 pool
+  "imageURI": "ipfs://…",
+  "website": "", "twitter": "https://x.com/…", "telegram": "",   // socials INLINE
+  "timestamp": 1784500460,             // creation, unix seconds
+  "blockNumber": "14202752",           // string
+  "pad": "0x…",                        // which pad factory launched it
+  "volume24Usd": 126496.83,            // the ONLY per-token traction field here
+  "kind": "direct"                     // "direct" | "curve"
+}
+```
+
+Gotchas:
+
+- **The only traction field is `volume24Usd`.** No holders, no per-token mcap,
+  no price, no trade count, no graduation flag. Market cap is computed by the
+  frontend from the V3 pool over `/api/rpc`, not served in this row.
+- **Socials are inline** (`website`/`twitter`/`telegram`) — no detail fetch
+  needed to enrich an alert with them (contrast noxa, whose list feed omits
+  socials).
+- **Symbols repeat.** Several live tokens share a symbol (multiple `POTATO`,
+  `MASH`, `CHIP`, `SPUD`) — they are distinct addresses. **Dedupe by address,
+  never symbol.**
+- **`blockNumber` is a string**; `timestamp` is unix **seconds**.
+- Placeholder **`test`** launches (name/symbol literally "test") show up with
+  real volume — filter them out of alerts.
+
+### `/api/ancient` `tokens` row shape (richer)
+
+```json
+{
+  "address": "0x…", "name": "…", "symbol": "…", "imageUrl": "ipfs://…",
+  "tradePool": "0x…", "feeTier": 10000,
+  "fdvUsd": 48733874.85,        // the baseline market cap (FDV at pool price)
+  "volume24Usd": 5184857.24,
+  "liquidityUsd": 4176923.05,
+  "hasWethPool": true
+}
+```
+
+Note the key name differences from Growing: `address` (not `token`), `imageUrl`
+(not `imageURI`), `tradePool` (not `pool`). No socials/creator/timestamp/kind on
+this feed. This is where fdv/liquidity live — a matured survivor (e.g. CASHCAT:
+$48.7M FDV, $4.2M liquidity, $5.2M 24h volume).
+
+### `/api/stats` shape
+
+```json
+{
+  "tokensLaunched": 60, "activeTokens": 30,
+  "volume24Usd": 1939007.88, "marketCapUsd": 1354430.45, "liquidityUsd": 460207.46,
+  "traders24": 4118, "trades24": 11053,
+  "volumeAllTimeUsd": 2588944.87, "tradesAllTime": 18394,
+  "unavailable": false, "updatedAt": 1784781131291
+}
+```
+
+Aggregates only (pad-wide), not per token. Confirms the pad is small and young.
+
+## On-chain identity (for a liveness fallback)
+
+Unused by the scanner (the pad events carry no traction field to score a bar on),
+but recorded for when the API dies (potato.fm's API *is* its web layer):
+
+- Chain: **Robinhood Chain, chainId 4663** (`eth_chainId` via `/api/rpc` → `0x1237`).
+- Tokens trade on **Uniswap V3**; each Growing row's `pool` / each Ancient row's
+  `tradePool` is the pool address.
+- Multiple **pad factory** contracts (the `pad` field). Six seen 2026-07-23,
+  e.g. `0x88eB8F4aC925C0a6b5501da0eb7E202a036EA338` (direct),
+  `0x94085E08B91dA3cB974c14FE6d51B20a014b6069` (curve).
+- GMGN indexes these as ordinary robinhood V3 tokens (by address), which is why
+  the tracker prices potato outcomes with the shared `snap_gmgn` rather than a
+  potato-specific snap.
+
+See `potato/scan.py` (the source-level scanner) and `potato/README.md`.

--- a/potato/README.md
+++ b/potato/README.md
@@ -1,0 +1,131 @@
+# potato/ — potato.fm ("Potato Pad"), source-level via potato.fm
+
+potato.fm is a launchpad on **Robinhood Chain** (chainId 4663, the same chain as
+pons/flap/noxa/long). "Potato Pad — PEOPLE'S LAUNCHPAD" plants a coin straight
+into a **locked Uniswap V3 position, live and tradable from the first block** —
+so `direct`-kind launches have no bonding curve to graduate. It is an
+**aggregator over several pad factory contracts** (six seen at first sight),
+each row tagged with its `pad` address and a `kind` (`direct` = straight-to-V3,
+`curve` = bonding-curve).
+
+Detect + rank + alert only. It never trades. Stdlib only.
+
+## Why a source-level scanner and not a GMGN trench rider
+
+The other Robinhood pads without their own scanner (bags, bankr, long) ride
+GMGN's Trenches board because reverse-engineering each isn't worth it. potato is
+worth it on both ends:
+
+- **potato.fm ships a clean public API** off its own Next.js origin — no auth,
+  and **urllib-reachable** (it is *not* Cloudflare-walled the way long.xyz's own
+  API is, which is what forced long onto GMGN). See
+  `docs/research/potato-fm-api.md`.
+- **The whole pad is tiny** — `/api/stats` showed ~60 tokens all-time at first
+  sight, ~30 active. One page of `/api/tokens` *is* the complete board, so this
+  gets **100% coverage**, which GMGN's fixed 50-row board can't give — and does
+  so before GMGN would even index a brand-new pad.
+
+## The two feeds are asymmetric on purpose
+
+potato.fm exposes exactly what the site itself shows, and the two boards carry
+different fields:
+
+| feed | role | traction fields |
+|---|---|---|
+| `GET /api/tokens` ("Growing") | discovery, 🥔 EARLY bar, control pool | **`volume24Usd` only** + socials (inline) + age + `kind`/`pad` |
+| `GET /api/ancient` ("Ancients") | 🚀 GRAD tier | **`fdvUsd` + `liquidityUsd` + `volume24Usd`** |
+
+A Growing row has **no per-token mcap/holders/price/trades** — the site computes
+market cap client-side from the V3 pool over RPC, which this scanner does not do.
+So the EARLY bar is **volume + age only**, and (unlike noxa) there is no
+`graduationPct` name-collision trap to sidestep — the field simply isn't there.
+
+Socials (`website`/`twitter`/`telegram`) are **inline on the Growing feed**, so
+an EARLY alert needs no per-token detail fetch (noxa needs one; potato doesn't).
+There is also no per-token detail endpoint — `/api/tokens/{addr}` 404s.
+
+## Tiers
+
+- **🥔 POTATO EARLY** — a young coin on the Growing board crossing the volume bar.
+- **🚀 POTATO GRAD** — a coin surfacing in the Ancients (matured onto a real
+  Uniswap V3 WETH pool), carrying real fdv/liquidity. Its *appearance* is the
+  event.
+
+The first successful poll of each feed **seeds silently** — for Growing, only
+the coins already over the bar (the strong backlog we must not re-alert on
+restart); sub-bar Growing coins are left un-seeded so a coin launched shortly
+before a restart can still alert if it crosses the bar afterwards.
+
+## Bar
+
+Volume + age only (the Growing feed carries no honeypot/tax/holders signal to
+gate on):
+
+| | vol24h | max age |
+|---|---|---|
+| **potato** | **$5K** | **24h** |
+
+v1 judgment call against the measured board (2026-07-23): the young end (coins
+<24h) sat almost entirely under $1K with a clean gap up to the one real mover
+(~$13–16K). $5K sits in that gap. Provisional like every bar here; refit from
+`data/events.jsonl` once outcomes accumulate.
+
+Deal flow is genuinely thin right now (~10 launches/24h, most fizzle
+immediately), so this fires rarely by design — a tight, high-signal bar on a
+nascent pad, not a firehose.
+
+## Scores are weaker on purpose
+
+This feed carries volume + socials (+ fdv/liquidity for grads) and **none** of
+GMGN's forensics (smart money, bot/insider/honeypot rates), so `score_item`
+rewards volume/socials/size and there are few red-flag cons. Honest v1 — the
+GMGN forensics recorded alongside each row (via `pons/outcomes.py`) are what the
+refit will actually lean on.
+
+## Pricing the outcome (track method: gmgn)
+
+Every potato alert prices by track method **`gmgn`** (chainSlug `robinhood`) —
+potato coins are ordinary Uniswap V3 tokens on Robinhood that GMGN indexes,
+unlike noxa V2 (invisible to GMGN, needs its own `snap_noxa`). So
+`tracker/track.py` needs **no** potato-specific method.
+
+- **GRAD** alerts carry `fdvUsd` as a real return baseline (`mcap0`).
+- **EARLY** alerts have no t0 mcap in the feed, so they record `mcap0=None` and
+  lean on the tracker's earliest-snapshot baseline (`report.py`'s documented
+  "baseline = price0 if present, else earliest snapshot"). Slightly conservative
+  — a first-5-minute pump lands in the baseline — but correct and self-healing.
+
+## Shadow controls (#9)
+
+One passed-over sub-bar Growing coin per open slot is recorded to
+`tracker/data/controls.jsonl` under platform `potato`. The measurable-baseline
+gate here is **`volume24Usd > 0`** (a coin that has traded has a GMGN price to
+snapshot) — the potato analog of noxa's `mcap > 0` gate, since potato has no
+per-token mcap. State in `data/control_slot.json`. See
+`docs/shadow-control-sampling.md`.
+
+## Liveness caveat
+
+potato.fm's API **is** its web layer, so if it goes down this scanner goes deaf
+(same failure mode as noxa/flap). It is also an unaudited demo MVP: `/api/tokens`
+occasionally 502s or times out under a cold scan cache — `get()` folds every
+such failure to None, so a bad poll is skipped, never fatal. The on-chain
+fallback (unused here — the pad factory events carry no traction field to score a
+bar on) is the pad `Creation`/launch event; the pad addresses ride on each row
+under `pad`.
+
+## Usage
+
+```bash
+python3 potato/scan.py --once      # one diagnostic pass: Growing vs the bar + Ancients
+python3 potato/scan.py --dry-run   # live loop, print alerts instead of sending
+python3 potato/scan.py             # live -> Telegram (pons/.env creds)
+```
+
+No API key needed (potato.fm is open). Telegram creds from `pons/.env`. Alerts
+are labelled `🥔 potato`, recorded to the tracker under platform `potato`, and
+priced by track method `gmgn`.
+
+24/7: `~/Library/LaunchAgents/com.sunrise.potato-scanner.plist`
+(logs -> `potato/data/potato_scan.log`). The watchdog auto-discovers it from the
+heartbeat at `potato/data/heartbeat.json`.

--- a/potato/scan.py
+++ b/potato/scan.py
@@ -1,0 +1,488 @@
+"""potato scanner — Robinhood Chain (chainId 4663), source-level via potato.fm.
+
+"Potato Pad — PEOPLE'S LAUNCHPAD" plants a coin straight into a locked Uniswap
+V3 position, live and tradable from the first block (no bonding curve on the
+`direct` kind). It runs on Robinhood Chain, the same chain as pons/flap/noxa/long,
+and is an **aggregator over several pad factory contracts** rather than a single
+launchpad — the `/api/tokens` feed carries a `pad` address and a `kind`
+(`direct` = straight-to-V3, `curve` = bonding-curve) on every row.
+
+Why its own source-level scanner and not a GMGN trench rider: potato.fm ships a
+clean public API off its own Next.js origin (no auth, urllib-reachable — it is
+NOT Cloudflare-walled the way long.xyz's own API is), and the whole pad is tiny
+enough (~60 tokens all-time at first sight) that one page IS the complete board.
+That is source-level, 100%-coverage freshness a fixed 50-row GMGN board can't
+match. Two feeds, deduped by address (symbols repeat — several live "MASH" and
+"POTATO" tokens are distinct addresses, so anything keyed on symbol would fold
+real coins together):
+
+    GET /api/tokens   -> {creations:[…]}  the "Growing" board: discovery, EARLY
+                                          bar, control pool. Socials are INLINE
+                                          (unlike noxa, so no per-alert detail
+                                          fetch). Only traction field: volume24Usd.
+    GET /api/ancient  -> {tokens:[…]}     the "Ancients": tokens matured into a
+                                          real WETH pool. RICHER than Growing —
+                                          carries fdvUsd + liquidityUsd + volume.
+
+The two feeds are asymmetric on purpose (it mirrors what the site itself has):
+a Growing row has no per-token mcap/holders/price/trades — the site computes
+market cap client-side from the V3 pool over RPC — so the EARLY bar is
+**volume + age** only, and scores are weaker than the trench scanners' (no
+holders, no 5m momentum, and none of GMGN's forensics — smart money, bot/insider
+/honeypot rates). Honest v1; refit the bar and weights from data/events.jsonl
+once outcomes accumulate, like every scanner here.
+
+Tiers:
+    🥔 POTATO EARLY  — a young coin on the Growing board crossing the volume bar.
+    🚀 POTATO GRAD   — a coin surfacing in the Ancients (matured to a WETH pool),
+                       carrying real fdv/liquidity. Appearance is the event.
+
+Pricing the outcome: a Growing row has no t0 mcap, so EARLY alerts record
+mcap0=None and lean on the tracker's earliest-snapshot baseline; GRAD alerts
+carry fdvUsd as a real baseline. Every potato alert prices by track method
+**gmgn** (chainSlug robinhood) — potato coins are ordinary Uniswap V3 tokens on
+robinhood that GMGN indexes, unlike noxa V2 which is invisible to GMGN and needs
+its own snap. tracker/track.py needs no potato-specific method as a result.
+
+Liveness caveat, same as noxa/flap: potato.fm's API IS its web layer, so if it
+goes down this scanner goes deaf. It is also an unaudited demo MVP and the
+/api/tokens endpoint occasionally 502s or times out under a cold scan cache —
+get() folds every such failure to None so a bad poll is skipped, never fatal.
+The on-chain fallback (unused here — the factory events carry no traction field
+to score a bar on) is the pad factory `Creation`/launch event; the pad addresses
+are on each row under `pad`.
+
+Alerts are labelled `🥔 potato` and recorded to the tracker under platform
+`potato`. Detect + rank + alert only. It never trades. Stdlib only.
+
+Usage:
+    python3 potato/scan.py --dry-run          # print alerts, no Telegram
+    python3 potato/scan.py --once             # one pass (candidates vs bar), exit
+    python3 potato/scan.py                     # live -> Telegram (pons/.env creds)
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import time
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "pons"))   # telegram + alertfmt + outcomes + controls + health
+import alertfmt  # noqa: E402
+import controls  # noqa: E402
+import health  # noqa: E402
+import outcomes  # noqa: E402
+import telegram  # noqa: E402
+
+# ---- scanner identity ------------------------------------------------------
+NAME = "potato"
+EMOJI = "🥔"
+PLATFORM = "potato"          # tracker platform key
+
+API = "https://potato.fm/api"
+COIN = "https://potato.fm/token/"
+BLOCKSCOUT = "https://robinhoodchain.blockscout.com/token/"
+
+# 🐣 EARLY traction bar — volume + age only. v1 judgment call, refit from
+# data/events.jsonl once outcomes accumulate.
+#
+# The Growing feed carries no per-token mcap/holders/trades — only volume24Usd —
+# so there is nothing else to gate on, and unlike noxa there is no graduationPct
+# name-collision trap to sidestep. Measured 2026-07-23 the young end of the board
+# (coins <24h) sat almost entirely under $1K, with a clean gap up to the one real
+# mover (~$13K). $5K sits in that gap: above the sub-$1K noise, below the mover.
+BAR = {"vol": 5_000.0}
+
+DATA = os.path.join(HERE, "data")
+os.makedirs(DATA, exist_ok=True)
+HEARTBEAT = os.path.join(DATA, "heartbeat.json")
+
+
+def log_event(kind, **kw):
+    try:
+        with open(os.path.join(DATA, "events.jsonl"), "a") as f:
+            f.write(json.dumps({"t": time.time(), "kind": kind, **kw}) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def fnum(d, key, default=0.0):
+    try:
+        return float(d.get(key) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def human(x, unit="$"):
+    if x is None:
+        return "?"
+    x = float(x)
+    if x >= 1_000_000:
+        return f"{unit}{x/1e6:.1f}M"
+    if x >= 1_000:
+        return f"{unit}{x/1e3:.1f}K"
+    return f"{unit}{x:.0f}"
+
+
+def get(path):
+    """One potato.fm GET -> parsed JSON, or None. Never raises into the loop.
+
+    potato.fm is an unaudited demo MVP: /api/tokens occasionally 502s or times
+    out while its scan cache is cold. Folding every failure to None means one bad
+    poll is skipped and the next one recovers — the same shape as noxa's get()."""
+    try:
+        req = urllib.request.Request(path, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def fetch_growing(limit=100):
+    """The Growing board rows (creations), or None on any failure.
+
+    None (fetch failed) is kept distinct from [] (empty board) so the caller can
+    decide whether to seed — the same distinction the trench scanners draw."""
+    d = get(f"{API}/tokens")
+    if not isinstance(d, dict) or d.get("unavailable"):
+        return None
+    items = d.get("creations")
+    if not isinstance(items, list) or not health.is_record_list(items):
+        return None
+    return items[:limit]
+
+
+def fetch_ancient(limit=100):
+    """The Ancients rows (matured tokens), or None on any failure."""
+    d = get(f"{API}/ancient")
+    if not isinstance(d, dict) or d.get("unavailable"):
+        return None
+    items = d.get("tokens")
+    if not isinstance(items, list) or not health.is_record_list(items):
+        return None
+    return items[:limit]
+
+
+def map_growing(r):
+    """A /api/tokens `creations` row -> the internal item shape.
+
+    Socials are inline here (website/twitter/telegram), so an EARLY alert needs
+    no per-token detail fetch. No mcap/holders/price/trades in this feed — the
+    site derives market cap from the V3 pool over RPC, which this scanner does
+    not do (see module docstring). volume24Usd is the only traction field."""
+    addr = (r.get("token") or "").lower()
+    return {
+        "address": addr,
+        "symbol": r.get("symbol"),
+        "name": r.get("name"),
+        "vol24h": fnum(r, "volume24Usd"),
+        "created_ts": r.get("timestamp") or 0,
+        "deployer": (r.get("creator") or "").lower(),
+        "pool": (r.get("pool") or "").lower(),
+        "pad": (r.get("pad") or "").lower(),
+        "kind": r.get("kind") or "direct",
+        "twitter": r.get("twitter") or None,
+        "telegram": r.get("telegram") or None,
+        "website": r.get("website") or None,
+        # Growing rows carry no per-token mcap/liquidity:
+        "mcap": None,
+        "liq": None,
+    }
+
+
+def map_ancient(r):
+    """A /api/ancient `tokens` row -> the internal item shape.
+
+    Richer than a Growing row: fdvUsd (the baseline mcap), liquidityUsd and
+    volume24Usd are all server-computed here. No socials/creator/timestamp/kind
+    on this feed, so a GRAD alert shows fdv/liq/vol rather than social pros."""
+    addr = (r.get("address") or "").lower()
+    return {
+        "address": addr,
+        "symbol": r.get("symbol"),
+        "name": r.get("name"),
+        "vol24h": fnum(r, "volume24Usd"),
+        "mcap": r.get("fdvUsd"),
+        "liq": r.get("liquidityUsd"),
+        "pool": (r.get("tradePool") or "").lower(),
+        "has_weth_pool": bool(r.get("hasWethPool")),
+        "created_ts": 0,
+        "kind": "ancient",
+        "twitter": None, "telegram": None, "website": None,
+    }
+
+
+def is_test(it):
+    """Obvious placeholder launches the pad's own docs/test flow leave behind
+    (name or symbol literally "test"). Kept out of alerts; harmless to skip."""
+    return (str(it.get("name") or "").strip().lower() == "test"
+            or str(it.get("symbol") or "").strip().lower() == "test")
+
+
+def age_min(it, now):
+    ts = it.get("created_ts") or 0
+    return (now - ts) / 60 if ts > 1_000_000_000 else None
+
+
+def passes_bar(it, args, now):
+    """The EARLY predicate. Volume + age only — the Growing feed carries no
+    holders/mcap/honeypot signal to gate on (see module docstring). Test-token
+    placeholders never pass."""
+    if is_test(it):
+        return False
+    am = age_min(it, now)
+    return ((am is None or am <= args.max_age_h * 60)
+            and it["vol24h"] >= args.min_vol)
+
+
+def score_item(it, base):
+    """Heuristic 0-100 from the potato.fm row. Deliberately thin: this feed has
+    volume + socials (+ fdv/liq for grads) and none of the forensic fields the
+    trench scanners score, so there is little here to fake a high score with —
+    and correspondingly few red-flag cons. Refit against tracker outcomes once
+    history accumulates."""
+    s = float(base)
+    v = it["vol24h"]
+    if v >= 100_000:
+        s += 6
+    elif v >= 20_000:
+        s += 4
+    elif v >= 5_000:
+        s += 2
+    if it.get("mcap") and float(it["mcap"]) >= 100_000:   # grads: real size
+        s += 3
+    if it.get("liq") and float(it["liq"]) >= 50_000:
+        s += 2
+    if it.get("twitter") or it.get("telegram"):
+        s += 3
+    if it.get("website"):
+        s += 2
+    return alertfmt.clamp(s)
+
+
+def links(addr):
+    return [[("📈 GMGN", f"https://gmgn.ai/robinhood/token/{addr}"),
+             ("📊 DexScreener", f"https://dexscreener.com/robinhood/{addr}")],
+            [("🥔 potato", f"{COIN}{addr}"),
+             ("🔗 Scan", f"{BLOCKSCOUT}{addr}")]]
+
+
+def build_alert(tier_emoji, tier, base, it, lead_pros, now):
+    score = score_item(it, base)
+    sym = html.escape(str(it.get("symbol") or it["address"][:8]))
+    pros = list(lead_pros)
+    socbits = []
+    if it.get("twitter"):
+        socbits.append("🐦 X")
+    if it.get("website"):
+        socbits.append("🌐 web")
+    if it.get("telegram"):
+        socbits.append("💬 TG")
+    if socbits:
+        pros.append(" · ".join(socbits))
+
+    cons = []
+    if it.get("kind") != "ancient" and not (it.get("twitter") or it.get("telegram") or it.get("website")):
+        cons.append("no socials")
+
+    am = age_min(it, now)
+    agebit = (f"{am/60:.1f}h" if am and am >= 60 else (f"{am:.0f}m" if am else "?"))
+    stats = [f"💰 mc {human(it.get('mcap'))} · 💧 liq {human(it.get('liq'))} "
+             f"· 📈 vol24h {human(it['vol24h'])} · ⏱️ {agebit}"]
+    addr = it["address"]
+    body = alertfmt.compose(score, tier_emoji, tier, sym, f"{EMOJI} {NAME}", "ROBINHOOD",
+                            pros, cons, stats,
+                            f'<a href="{BLOCKSCOUT}{addr}">{addr[:12]}…</a>')
+    return score, body
+
+
+def track_dict(addr):
+    # potato coins are ordinary Uniswap V3 tokens on robinhood chain that GMGN
+    # indexes, so the outcome prices via the shared gmgn snap — no potato method
+    # in tracker/track.py. (noxa needs its own snap because V2 is gmgn-invisible.)
+    return {"method": "gmgn", "chainSlug": "robinhood", "address": addr}
+
+
+def record_for(it, tier, score):
+    return dict(platform=PLATFORM, chain="ROBINHOOD", tier=tier,
+                symbol=str(it.get("symbol") or it["address"][:8]), token=it["address"],
+                score=score, track=track_dict(it["address"]),
+                price0=None, mcap0=it.get("mcap"), liq0=it.get("liq"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--interval", type=float, default=30.0, help="poll (s)")
+    ap.add_argument("--max-age-h", type=float, default=24.0, help="EARLY only for coins younger than this")
+    ap.add_argument("--min-vol", type=float, default=BAR["vol"], help="volume_24h USD")
+    ap.add_argument("--limit", type=int, default=100, help="rows per feed")
+    ap.add_argument("--once", action="store_true", help="one pass, print candidates vs bar, exit")
+    ap.add_argument("--dry-run", action="store_true")
+    controls.add_args(ap)
+    args = ap.parse_args()
+
+    token_tg, chat_id = telegram.load_creds()
+    dry = args.dry_run or not (token_tg and chat_id)
+
+    if args.once:
+        rows = fetch_growing(args.limit) or []
+        now = time.time()
+        print(f"### /api/tokens (Growing): {len(rows)}")
+        for r in rows:
+            it = map_growing(r)
+            am = age_min(it, now)
+            print(f"  {str(it.get('symbol'))[:14]:<14} {it['kind']:<6} "
+                  f"vol24h={human(it['vol24h']):>8} "
+                  f"soc={'Y' if (it.get('twitter') or it.get('telegram') or it.get('website')) else ' '} "
+                  f"age={f'{am:.0f}m' if am else '?':>6} "
+                  f"{'BAR✓' if passes_bar(it, args, now) else ''}")
+        anc = fetch_ancient(args.limit) or []
+        print(f"### /api/ancient (Ancients): {len(anc)}")
+        for r in anc:
+            it = map_ancient(r)
+            print(f"  {str(it.get('symbol'))[:14]:<14} fdv={human(it.get('mcap')):>8} "
+                  f"liq={human(it.get('liq')):>8} vol24h={human(it['vol24h']):>8}")
+        return
+
+    print(f"{NAME} scanner (potato.fm, robinhood)  "
+          f"bar: vol24h>=${args.min_vol:.0f} & age<={args.max_age_h:.0f}h  "
+          f"-> {'DRY-RUN' if dry else f'Telegram {chat_id}'}", flush=True)
+
+    def dispatch(text, label, buttons=None, record=None):
+        stamp = time.strftime("%H:%M:%S")
+        if dry:
+            print(f"[{stamp}] DRY {label}\n" + text, flush=True)
+            return
+        ok, info = telegram.send(text, token_tg, chat_id, buttons=buttons)
+        if record and ok:
+            record["tg"] = {"msg_id": info if isinstance(info, int) else None,
+                            "text": text, "buttons": buttons}
+            outcomes.record_alert(**record)   # only record alerts that actually sent
+        print(f"[{stamp}] {'sent -> ' + label if ok else 'send FAILED (' + label + '): ' + info}", flush=True)
+
+    sampler = controls.ControlSampler(
+        PLATFORM, k=args.controls_k, bucket_s=args.controls_bucket_s,
+        state_path=os.path.join(DATA, "control_slot.json"))
+    seen_new = set()     # addresses already registered from the Growing feed
+    early_sent = set()
+    grad_sent = set()
+    seeded = set()       # feeds that had one successful poll (silent seed pass)
+
+    def sample_control(now, pool):
+        """One Growing coin we evaluated and passed over becomes a control (#9).
+
+        Drawn from the sub-bar coins with a measurable baseline — here that means
+        volume24Usd > 0 (a coin that has traded has a GMGN price to snapshot; a
+        just-minted $0-volume coin has no t0 to measure a return from and would
+        spend a control slot on an unmeasurable row). This is the potato analog
+        of noxa's mcap>0 gate — potato has no per-token mcap, but volume>0 is the
+        same "has a baseline" test. See docs/shadow-control-sampling.md."""
+        picked = sampler.choose(now, pool, key=lambda x: x["address"])
+        if picked is None:
+            return
+        addr = picked["address"]
+        log_event("control", addr=addr, sym=picked.get("symbol"),
+                  vol=picked["vol24h"], pad_kind=picked.get("kind"))
+        outcomes.record_control(PLATFORM, "ROBINHOOD",
+                                str(picked.get("symbol") or addr[:8]), addr,
+                                track_dict(addr))
+
+    def handle_grad(it, now, first):
+        addr = it["address"]
+        if not addr or addr in grad_sent:
+            return
+        grad_sent.add(addr)
+        if first:
+            return                 # backlog: seed silently
+        score, body = build_alert("🚀", "POTATO GRAD", 50, it, [
+            "🚀 matured — live on a Uniswap V3 WETH pool",
+        ], now)
+        log_event("grad_alert", addr=addr, sym=it.get("symbol"), score=score,
+                  mc=it.get("mcap"), liq=it.get("liq"), vol=it["vol24h"])
+        dispatch(body, f"POTATO GRAD {it.get('symbol')}", buttons=links(addr),
+                 record=record_for(it, "POTATO GRAD", score))
+
+    def handle_early(it, now, first, pool):
+        addr = it["address"]
+        if not addr or addr in early_sent or addr in grad_sent:
+            return
+        if first:
+            # Seed only the coins ALREADY over the bar — the strong backlog we
+            # must not re-alert on restart. Sub-bar coins are left un-seeded on
+            # purpose so a coin launched shortly before a restart can still alert
+            # if it crosses the bar afterwards (a real crossing, not backlog).
+            if passes_bar(it, args, now):
+                early_sent.add(addr)
+            return
+        if not passes_bar(it, args, now):
+            # Control population (#9): sub-bar coins we evaluated and passed over,
+            # restricted to those with a measurable baseline (volume > 0).
+            if not is_test(it) and it["vol24h"] > 0:
+                pool.append(it)
+            return
+        early_sent.add(addr)
+        score, body = build_alert("🥔", "POTATO EARLY", 42, it, [
+            f"📈 vol24h {human(it['vol24h'])} · {it['kind']}"
+            + (f" · {it['name']}" if it.get("name") else ""),
+        ], now)
+        log_event("early_alert", addr=addr, sym=it.get("symbol"), score=score,
+                  vol=it["vol24h"], pad_kind=it.get("kind"), pad=it.get("pad"))
+        dispatch(body, f"POTATO EARLY {it.get('symbol')}", buttons=links(addr),
+                 record=record_for(it, "POTATO EARLY", score))
+
+    def poll(now):
+        grow_rows = fetch_growing(args.limit)
+        anc_rows = fetch_ancient(args.limit)
+        if grow_rows is None and anc_rows is None:
+            print(f"[{time.strftime('%H:%M:%S')}] potato.fm fetch failed", flush=True)
+            return
+        pool = []   # sub-bar Growing coins this poll, for one control draw
+
+        if grow_rows is not None:
+            first = "grow" not in seeded
+            for r in grow_rows:
+                it = map_growing(r)
+                if not it["address"]:
+                    continue
+                if it["address"] not in seen_new:
+                    seen_new.add(it["address"])
+                    if not first:
+                        log_event("launch", addr=it["address"], sym=it.get("symbol"),
+                                  deployer=it.get("deployer"), pad_kind=it.get("kind"),
+                                  pad=it.get("pad"))
+                handle_early(it, now, first, pool)
+            if not first:
+                sample_control(now, pool)
+            seeded.add("grow")
+
+        if anc_rows is not None:
+            first = "ancient" not in seeded
+            for r in anc_rows:
+                it = map_ancient(r)
+                if not it["address"]:
+                    continue
+                handle_grad(it, now, first)
+            seeded.add("ancient")
+
+        health.touch(HEARTBEAT, NAME, now=now,
+                     detail={"growing": len(grow_rows or []), "ancient": len(anc_rows or [])})
+
+    print("running… Ctrl-C to stop", flush=True)
+    while True:
+        try:
+            poll(time.time())
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            print("\nstopped", flush=True)
+            break
+        except Exception as e:  # noqa: BLE001
+            print(f"  loop error: {e}", flush=True)
+            time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_potato_scan.py
+++ b/tests/test_potato_scan.py
@@ -1,0 +1,137 @@
+"""potato scanner — identity, the volume-only bar, and the gmgn track method.
+
+potato/ is a source-level scanner over potato.fm (a Robinhood-chain Uniswap-V3
+launchpad aggregator), not a GMGN trench rider, so it carries its own
+map_growing / map_ancient / passes_bar / score_item. These tests pin the things
+that would fail silently:
+
+  - the track method is **gmgn**, not "potato" — potato coins are ordinary V3
+    tokens GMGN indexes, so a "potato" method would leave every alert unpriceable
+    (there is no snap_potato in tracker/track.py, by design);
+  - the EARLY bar gates on volume + age only (the Growing feed has no holders/
+    mcap), and a placeholder "test" launch or an over-age coin must not pass;
+  - a GRAD row carries fdvUsd as a real baseline while an EARLY row carries none;
+  - scores separate a strong coin from a thin one.
+
+Direction and separation only, never exact score values — the weights are
+provisional until the refit, same rule as the rest of tests/.
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NOW = 1_784_780_000            # a fixed "now" the fixtures are aged against
+
+
+@pytest.fixture(scope="session")
+def potato():
+    sys.path.insert(0, os.path.join(ROOT, "pons"))
+    spec = importlib.util.spec_from_file_location("potato_scan", os.path.join(ROOT, "potato", "scan.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["potato_scan"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _args(**kw):
+    base = dict(max_age_h=24.0, min_vol=5_000.0)
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+# a strong young Growing coin (BLUECHIP on the live board, 2026-07-23):
+STRONG = {"token": "0xBb31694F74B11b38D05566fcf25398360B6b531b", "symbol": "BLUECHIP",
+          "name": "Blue Chip", "creator": "0xAbC", "pool": "0xpool",
+          "pad": "0x94085E08B91dA3cB974c14FE6d51B20a014b6069", "kind": "curve",
+          "website": "https://x.example", "twitter": "https://x.com/bluechip", "telegram": "",
+          "volume24Usd": 16_300.0, "timestamp": NOW - 3600}       # 1h old
+# a thin young sub-bar coin
+THIN = {"token": "0x0000000000000000000000000000000000000001", "symbol": "SPUD",
+        "name": "Spud", "creator": "0xDef", "pool": "0xp2", "pad": "0x12A075A9",
+        "kind": "direct", "website": "", "twitter": "", "telegram": "",
+        "volume24Usd": 200.0, "timestamp": NOW - 3600}            # 1h old
+# a placeholder test launch (real: the pad's test flow leaves these behind)
+TESTTOK = {"token": "0x0000000000000000000000000000000000000002", "symbol": "TEST",
+           "name": "test", "creator": "0xDef", "pool": "0xp3", "pad": "0x94085E08",
+           "kind": "curve", "website": "https://potato.fm", "twitter": "", "telegram": "",
+           "volume24Usd": 29_700.0, "timestamp": NOW - 3600}      # over the bar but a test
+# a matured Ancient row (CASHCAT on the live board):
+ANCIENT = {"address": "0x020bfc650a365f8bb26819deaabf3e21291018b4", "name": "Cash Cat",
+           "symbol": "CASHCAT", "imageUrl": "ipfs://x", "tradePool": "0xa70f",
+           "feeTier": 10000, "fdvUsd": 48_733_874.0, "volume24Usd": 5_184_857.0,
+           "liquidityUsd": 4_176_923.0, "hasWethPool": True}
+
+
+def test_identity_and_track_method(potato):
+    # The non-obvious one: the price-source method is gmgn (potato coins are
+    # gmgn-indexable V3 tokens), while the platform label is potato. A "potato"
+    # method would file alerts that tracker/track.py can never price.
+    assert potato.NAME == "potato"
+    assert potato.PLATFORM == "potato"
+    # track_dict passes the address through as-is (map_* already lower-cased it).
+    assert potato.track_dict("0xabc") == {"method": "gmgn", "chainSlug": "robinhood", "address": "0xabc"}
+
+
+def test_strong_young_coin_passes_bar(potato):
+    assert potato.passes_bar(potato.map_growing(STRONG), _args(), NOW) is True
+
+
+def test_thin_coin_fails_the_bar(potato):
+    assert potato.passes_bar(potato.map_growing(THIN), _args(), NOW) is False
+
+
+def test_test_token_never_passes_bar(potato):
+    # over the volume bar and young, but a literal "test" placeholder — excluded.
+    it = potato.map_growing(TESTTOK)
+    assert it["vol24h"] >= 5_000.0                      # would clear a naive vol gate
+    assert potato.is_test(it) is True
+    assert potato.passes_bar(it, _args(), NOW) is False
+
+
+def test_over_age_coin_fails_the_bar(potato):
+    old = dict(STRONG, timestamp=NOW - 200 * 3600)      # 200h old, still over vol
+    assert potato.passes_bar(potato.map_growing(old), _args(), NOW) is False
+
+
+def test_score_separates_strong_from_thin(potato):
+    assert potato.score_item(potato.map_growing(STRONG), 42) > potato.score_item(potato.map_growing(THIN), 42)
+
+
+def test_map_growing_lowercases_address_and_reads_inline_socials(potato):
+    it = potato.map_growing(STRONG)
+    assert it["address"] == STRONG["token"].lower()
+    # socials are inline on the Growing feed — no per-alert detail fetch needed.
+    assert it["twitter"] == "https://x.com/bluechip"
+    assert it["mcap"] is None and it["liq"] is None      # no per-token mcap on Growing
+
+
+def test_map_ancient_reads_fdv_and_liquidity(potato):
+    it = potato.map_ancient(ANCIENT)
+    assert it["address"] == ANCIENT["address"]           # already lower-case
+    assert it["mcap"] == 48_733_874.0                    # fdvUsd is the baseline mcap
+    assert it["liq"] == 4_176_923.0
+
+
+def test_early_record_has_no_baseline_grad_record_does(potato):
+    # EARLY (Growing) has no t0 mcap -> mcap0 None (tracker uses earliest snapshot).
+    early = potato.record_for(potato.map_growing(STRONG), "POTATO EARLY", 55)
+    assert early["platform"] == "potato"
+    assert early["mcap0"] is None
+    assert early["track"]["method"] == "gmgn"
+    # GRAD (Ancient) carries fdvUsd as a real return baseline.
+    grad = potato.record_for(potato.map_ancient(ANCIENT), "POTATO GRAD", 60)
+    assert grad["mcap0"] == 48_733_874.0
+    assert grad["liq0"] == 4_176_923.0
+
+
+def test_alert_body_is_labelled_potato_and_well_formed(potato):
+    it = potato.map_growing(STRONG)
+    score, body = potato.build_alert("🥔", "POTATO EARLY", 42, it, ["lead"], NOW)
+    assert "🥔 potato" in body
+    assert "POTATO EARLY" in body
+    assert 0 <= score <= 100


### PR DESCRIPTION
## What

Adds a source-level scanner for **potato.fm** ("Potato Pad"), a Robinhood-chain
(4663) launchpad that **aggregates several pad factories** (`kind` `direct`/`curve`)
and plants coins straight into a locked Uniswap V3 position, live from block one.

Mirrors `noxa/` (source-level, not a GMGN trench rider) because potato.fm ships an
open, urllib-reachable API off its own Next.js origin (not Cloudflare-walled like
long.xyz), and the pad is small enough that one page of `/api/tokens` *is* the
complete board — 100% coverage.

## How

- **Two feeds:** `/api/tokens` (Growing) drives 🥔 **POTATO EARLY** on a volume+age
  bar — the only per-token traction the feed carries (socials are inline; no
  holders/mcap). `/api/ancient` (matured, richer: fdv/liquidity) drives 🚀 **POTATO
  GRAD**.
- **Pricing:** outcomes price via the shared `gmgn` snap (potato coins are
  gmgn-indexable V3 tokens), so `tracker/track.py` needs **no** potato-specific
  method. EARLY records no t0 mcap and leans on the earliest-snapshot baseline;
  GRAD carries `fdvUsd`.
- **Shadow controls** gate on `volume > 0` (potato's "has a measurable baseline"
  test — the analog of noxa's `mcap > 0`). Seeding, heartbeat, event log mirror noxa.
- Reuses pons shared modules (alertfmt/controls/health/outcomes/telegram);
  stdlib-only.

## Scope note

potato is tiny and young (~60 tokens all-time, thin deal flow) and its API is a
demo MVP that occasionally 502s/times out — `get()` folds every failure to None.
The bar ($5K vol / 24h) and scores are provisional v1 judgment calls, to be refit
from `data/events.jsonl` + tracker outcomes once history accumulates, like every
scanner here.

## Tests

- `tests/test_potato_scan.py` (10 tests): identity, the `gmgn` track method, the
  volume+age bar, the test-token filter, and EARLY-vs-GRAD baselines.
- Full suite green (243 passed, 1 expected xfail).

## Deploy

Already running 24/7 as `com.sunrise.potato-scanner`; the watchdog auto-discovers
it from `potato/data/heartbeat.json`. Docs: `potato/README.md` +
`docs/research/potato-fm-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM3wUUrtwALc74LWm6hv5q